### PR TITLE
fix for the max flow algorithm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/alonsovidales/go_graph
+
+go 1.20
+
+require github.com/alonsovidales/go_fibanaccy_heap v0.0.0-20150112215134-e773bf8d240f

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/alonsovidales/go_fibanaccy_heap v0.0.0-20150112215134-e773bf8d240f h1:Xj2b9yZ8eGMJTLhV/2y8q/jp/NKb7QMD0pA0H+6Kpek=
+github.com/alonsovidales/go_fibanaccy_heap v0.0.0-20150112215134-e773bf8d240f/go.mod h1:6LE0cxVlGnmUuB2Zo4ihnip+88xnd89hr58HAgy2pxQ=

--- a/graph.go
+++ b/graph.go
@@ -1,9 +1,10 @@
 package graphs
 
 import (
-	"github.com/alonsovidales/go_fibanaccy_heap"
 	"math"
 	"sort"
+
+	"github.com/alonsovidales/go_fibanaccy_heap"
 )
 
 // Graph Data strcture used to represent a graph, the VertexEdges var
@@ -108,7 +109,7 @@ func GetGraph(edges []Edge, undirected bool) (ug *Graph) {
 // The precission param is usefull in order to find a max flow in graphs with
 // edges with float weights in order to avoid large execution times.
 // Ford-Fulkerson algorithm:
-// 	- http://en.wikipedia.org/wiki/Ford%E2%80%93Fulkerson_algorithm
+//   - http://en.wikipedia.org/wiki/Ford%E2%80%93Fulkerson_algorithm
 func (gr *Graph) MinCutMaxFlow(orig, dest uint64, precision float64) (maxFlowMinCut float64, flows map[uint64]map[uint64]float64, cut []*Edge) {
 	// This map will contain the reverse edge relations
 	undirEdges := make(map[uint64][]uint64)
@@ -134,6 +135,11 @@ func (gr *Graph) MinCutMaxFlow(orig, dest uint64, precision float64) (maxFlowMin
 				flows[f][v] = 0.0
 			} else {
 				flows[f] = map[uint64]float64{v: 0.0}
+			}
+			if _, ok := flows[v]; ok {
+				flows[v][f] = 0.0
+			} else {
+				flows[v] = map[uint64]float64{f: 0.0}
 			}
 		}
 	}
@@ -258,9 +264,10 @@ func (gr *Graph) ShortestPath(origin, dest uint64) (path []uint64, dist map[uint
 
 // Mst Minimum Spanning Tree, Calculates the tree of edges who connects all the vertices with a minimun cost
 // This method uses the Kruskal's algorithm:
-//	- http://en.wikipedia.org/wiki/Kruskal%27s_algorithm
+//   - http://en.wikipedia.org/wiki/Kruskal%27s_algorithm
+//
 // An Union-find in order to detect cycles:
-//	- http://en.wikipedia.org/wiki/Disjoint-set_data_structure
+//   - http://en.wikipedia.org/wiki/Disjoint-set_data_structure
 func (gr *Graph) Mst() (mst []Edge) {
 	var edgeToAdd, groupID uint64
 	mst = []Edge{}
@@ -356,7 +363,7 @@ func (gr *Graph) NewReversedGraph() (rev *Graph) {
 // is used as a set who groups the vertices by groups, the keys of the maps
 // are vertex number
 // The algorithm used is the Kosaraju-Sharir's algorithm:
-// 	- http://en.wikipedia.org/wiki/Kosaraju%27s_algorithm
+//   - http://en.wikipedia.org/wiki/Kosaraju%27s_algorithm
 func (gr *Graph) StronglyConnectedComponents() (components map[uint64]int64, compGroups []map[uint64]bool) {
 	currentGroup := int64(0)
 	components = make(map[uint64]int64)
@@ -640,9 +647,10 @@ func (gr *Graph) Bfs(origin uint64) (edgeTo map[uint64]uint64, distTo map[uint64
 // Dfs Finds all vertices connected to the "origin" vertex  and returns them as
 // an slice of vertices.
 // This method uses Depth-first search algorithm:
-//	- http://en.wikipedia.org/wiki/Depth-first_search
+//   - http://en.wikipedia.org/wiki/Depth-first_search
+//
 // The Tremaux's algorithm is used to perform this search:
-//	- http://en.wikipedia.org/wiki/Maze_solving_algorithm#Tr.C3.A9maux.27s_algorithm
+//   - http://en.wikipedia.org/wiki/Maze_solving_algorithm#Tr.C3.A9maux.27s_algorithm
 func (gr *Graph) Dfs(root uint64) (usedVertex map[uint64]bool) {
 	usedVertex = make(map[uint64]bool)
 	gr.dfs(root, usedVertex, nil, nil)
@@ -683,11 +691,9 @@ func (gr *Graph) recalcFlows(path []uint64, flows map[uint64]map[uint64]float64)
 
 	f = path[0]
 	for _, t := range path[1:] {
-		if _, issetPath := gr.VertexEdges[f][t]; issetPath {
-			flows[f][t] += toAdd
-		} else {
-			flows[t][f] -= toAdd
-		}
+		flows[f][t] += toAdd
+		flows[t][f] -= toAdd
+
 		f = t
 	}
 }

--- a/graph_test.go
+++ b/graph_test.go
@@ -1,10 +1,10 @@
 package graphs
 
 import (
-	//"math/rand"
+	// "math/rand"
 	"reflect"
 	"testing"
-	//"fmt"
+	// "fmt"
 )
 
 // This test checks if we can get by DFS the two paths that connects all the
@@ -593,6 +593,47 @@ func TestMinCutMaxFlow2(t *testing.T) {
 		&Edge{1, 2, 5},
 		&Edge{3, 4, 3},
 		&Edge{3, 5, 1},
+	}
+
+	for _, ec := range expectedCut {
+		found := false
+		for _, c := range cut {
+			if reflect.DeepEqual(ec, c) {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("Expected cut:", ec, "not found")
+		}
+	}
+}
+
+func TestMinCutMaxFlow3(t *testing.T) {
+	gr := GetGraph(
+		[]Edge{
+			Edge{0, 1, 16},
+			Edge{0, 2, 13},
+			Edge{1, 2, 10},
+			Edge{1, 3, 12},
+			Edge{2, 1, 4},
+			Edge{2, 4, 14},
+			Edge{3, 2, 9},
+			Edge{3, 5, 20},
+			Edge{4, 3, 7},
+			Edge{4, 5, 4},
+		},
+		false,
+	)
+
+	maxFlow, _, cut := gr.MinCutMaxFlow(0, 5, 0.01)
+	if maxFlow != 23 {
+		t.Error("Expected max flow for the given graph: 23 but obtained:", maxFlow)
+	}
+
+	expectedCut := []*Edge{
+		&Edge{4, 5, 4},
+		&Edge{4, 3, 7},
+		&Edge{1, 3, 12},
 	}
 
 	for _, ec := range expectedCut {


### PR DESCRIPTION
This is the third and last of my PRs.

First of all, this PR is based on the first one - introducting go modules support. Without it neither go get or go install could install the fibonacci dependency on the fresh Go.

I added a new test case for the max flow problem. Without the fix it fails around 70% of the time (50% with my second PR though... just a curious detail). It manifests here because the sample graph have two edges between 1 and 2 nodes - one in each direction.

The problem was in condition in flow update, while on Wikipedia (you have the link to that article in your comment above MaxFlowMinCut func), there is no such condition is mentioned.
Changing that required to modify flows initialisation.

That fixes it.